### PR TITLE
Add GHA workflow to notify Slack for dependency changes

### DIFF
--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -1,0 +1,40 @@
+---
+name: Send Slack notifications
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      # Not exactly the same as pyproject.toml tool.robotpy but close enough
+      - uv.lock
+
+permissions:
+  contents: read
+
+jobs:
+  deps:
+    runs-on: ubuntu-slim
+
+    steps:
+      - name: Post a message in a channel
+        uses: slackapi/slack-github-action@v2
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            text: ":mega: Robot dependencies have been updated!"
+            blocks:
+              - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: >-
+                    :mega: Robot dependencies have been updated! Please rebase all open PRs,
+                    and download the new dependencies by following the
+                    <${{ github.server_url }}/${{ github.repository }}#install-dependencies|instructions in the readme>.
+              - type: "context"
+                elements:
+                  - type: "mrkdwn"
+                    text: >-
+                      Triggered on ${{ github.event_name }} for commit
+                      <${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}|${{ github.sha }}>


### PR DESCRIPTION
This sends a Slack message to #software via a [Slack incoming webhook](https://my.slack.com/marketplace/A0F7XDUAZ-incoming-webhooks)* whenever our robot dependencies are updated. The intent is to avoid the pain of the deploy process yelling at people on old branches (and subsequently having to reconnect to the internet to download dependencies).

The message links to https://github.com/thedropbears/pyrebuilt#install-dependencies

\* yes, I know [incoming webhooks are deprecated](https://docs.slack.dev/legacy/legacy-custom-integrations/legacy-custom-integrations-incoming-webhooks/)