### PR TITLE
Add test to ensure dependency lists are in sync

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,7 +110,7 @@ requires = [
     "phoenix6~=26.1.0",
     "robotpy-ctre~=2026.1.0",
     "robotpy-rev==2026.0.1",
-    "robotpy-wpilib-utilities==2026.0.1",
+    "robotpy-wpilib-utilities~=2026.0.1",
     "photonlibpy==2026.1.1rc3",
     "sleipnirgroup-choreolib~=2026.0.1",
 ]

--- a/tests/test_pyproject.py
+++ b/tests/test_pyproject.py
@@ -1,0 +1,17 @@
+import tomllib
+
+
+def test_robotpy_dependencies() -> None:
+    with open("pyproject.toml", "rb") as f:
+        data = tomllib.load(f)
+
+    project_dependencies = data["project"]["dependencies"]
+    robotpy_table = data["tool"]["robotpy"]
+
+    robotpy_components = ",".join(robotpy_table["components"])
+    robotpy_version = robotpy_table["robotpy_version"]
+    expected_robotpy_dependency = f"robotpy[{robotpy_components}]=={robotpy_version}"
+    assert expected_robotpy_dependency in project_dependencies
+
+    for dependency in robotpy_table["requires"]:
+        assert dependency in project_dependencies


### PR DESCRIPTION
This test caught one version specifier that doesn't match. Oops.