### PR TITLE
Rename noun-phrase component methods to imperative verb phrases

### DIFF
--- a/components/ballistics.py
+++ b/components/ballistics.py
@@ -30,8 +30,8 @@ class BallisticsComponent:
 
     def setup(self) -> None:
         self.target_flywheel_speed = 0.0
-        self.target_turret_angle = self.turret.current_angle()
-        self.target_hood_angle = self.shooter.hood_angle()
+        self.target_turret_angle = self.turret.get_current_angle()
+        self.target_hood_angle = self.shooter.get_hood_angle()
 
     def energise_flywheels(self) -> None:
         # assuming that we dont want to have the flywheel spun up all the time,

--- a/components/shooter.py
+++ b/components/shooter.py
@@ -70,19 +70,19 @@ class ShooterComponent:
 
         configure_spark_reset_and_persist(self.hood_motor, hood_motor_cfg)
 
-        self.target_hood_angle = self.hood_angle()
+        self.target_hood_angle = self.get_hood_angle()
 
     @feedback
-    def hood_angle_degrees(self) -> units.degrees:
-        return math.degrees(self.hood_angle())
+    def get_hood_angle_degrees(self) -> units.degrees:
+        return math.degrees(self.get_hood_angle())
 
-    def hood_angle(self) -> units.radians:
+    def get_hood_angle(self) -> units.radians:
         return self.hood_encoder.getPosition()
 
     @feedback
     def hood_is_at_setpoint(self) -> bool:
         return math.isclose(
-            self.hood_angle(),
+            self.get_hood_angle(),
             self.target_hood_angle,
             abs_tol=self.hood_error_tolerance,
         )

--- a/components/turret.py
+++ b/components/turret.py
@@ -70,14 +70,14 @@ class TurretComponent:
 
     def setup(self) -> None:
         self._sync_encoder()
-        self.slew_to(self.current_angle())
+        self.slew_to(self.get_current_angle())
 
     def on_enable(self) -> None:
         self._sync_encoder()
-        self.slew_to(self.current_angle())
+        self.slew_to(self.get_current_angle())
 
     @feedback
-    def raw_absolute_encoder(self) -> float:
+    def get_raw_absolute_encoder(self) -> float:
         return self.absolute_encoder.get()
 
     @feedback
@@ -88,19 +88,19 @@ class TurretComponent:
         self.relative_encoder.setPosition(self._get_absolute_encoder_position())
 
     @feedback
-    def current_angle(self) -> units.radians:
+    def get_current_angle(self) -> units.radians:
         return self.relative_encoder.getPosition()
 
     @feedback
-    def current_velocity(self) -> units.radians_per_second:
+    def get_current_velocity(self) -> units.radians_per_second:
         return self.relative_encoder.getVelocity()
 
     @feedback
-    def error(self) -> units.radians:
-        return self.controller.getMAXMotionSetpointPosition() - self.current_angle()
+    def get_error(self) -> units.radians:
+        return self.controller.getMAXMotionSetpointPosition() - self.get_current_angle()
 
     def slew_relative(self, angle: units.radians) -> None:
-        self.slew_to(self.current_angle() + angle)
+        self.slew_to(self.get_current_angle() + angle)
 
     def slew_to(self, angle: units.radians) -> None:
         # update setpoint
@@ -113,4 +113,4 @@ class TurretComponent:
         )
 
     def periodic(self) -> None:
-        self.sim_pointer.setAngle(math.degrees(self.current_angle()))
+        self.sim_pointer.setAngle(math.degrees(self.get_current_angle()))

--- a/components/vision.py
+++ b/components/vision.py
@@ -165,7 +165,7 @@ class VisualLocalizer(HasPerLoopCache):
         self.override_setpoint = 0.5
 
     @feedback
-    def rotation_limits(self) -> list[float]:
+    def get_rotation_limits(self) -> list[float]:
         return [self.min_rotation, self.max_rotation]
 
     @feedback
@@ -177,7 +177,7 @@ class VisualLocalizer(HasPerLoopCache):
         return self.has_multitag
 
     @feedback
-    def raw_encoder_rotation(self) -> Rotation2d:
+    def get_raw_encoder_rotation(self) -> Rotation2d:
         # The encoder has been set up to return values in the interval [0, 2pi]
         return Rotation2d(self.encoder.get())
 
@@ -188,7 +188,7 @@ class VisualLocalizer(HasPerLoopCache):
     @feedback
     @cache_per_loop
     def relative_bearing_to_best_cluster(self) -> float:
-        tags = self.visible_tags()
+        tags = self.get_visible_tags()
         if len(tags) == 0:
             return 0.0
         relative_bearings = [tag.relative_bearing for tag in tags]
@@ -206,7 +206,7 @@ class VisualLocalizer(HasPerLoopCache):
 
     @feedback
     @cache_per_loop
-    def visible_tags(self) -> list[VisibleTag]:
+    def get_visible_tags(self) -> list[VisibleTag]:
         tags_in_view = []
 
         robot_pose = self.chassis.get_pose()
@@ -248,20 +248,20 @@ class VisualLocalizer(HasPerLoopCache):
         return tags_in_view
 
     @feedback
-    def desired_turret_rotation(self) -> float:
+    def get_desired_turret_rotation(self) -> float:
         # Read encoder angle and account for offset
         return self.relative_bearing_to_best_cluster()
 
     @feedback
-    def desired_servo_rotation(self) -> float:
-        return self.turret_to_servo(self.desired_turret_rotation())
+    def get_desired_servo_rotation(self) -> float:
+        return self.convert_turret_to_servo(self.get_desired_turret_rotation())
 
-    def turret_to_servo(self, turret: float) -> float:
+    def convert_turret_to_servo(self, turret: float) -> float:
         return turret - (self.servo_offsets.neutral - self.encoder_offset).radians()
 
     @property
     def turret_rotation(self) -> Rotation2d:
-        return self.raw_encoder_rotation() - self.encoder_offset
+        return self.get_raw_encoder_rotation() - self.encoder_offset
 
     def robot_to_camera(self, timestamp: float) -> Transform3d:
         turret_rotation = self.turret_rotation_buffer.sample(timestamp)
@@ -294,7 +294,7 @@ class VisualLocalizer(HasPerLoopCache):
         self.override_setpoint = 0.99
 
     def execute(self) -> None:
-        desired = self.turret_to_servo(self.desired_turret_rotation())
+        desired = self.convert_turret_to_servo(self.get_desired_turret_rotation())
         new_turret_setpoint = clamp(
             (desired / self.servo_half_range + 1.0) / 2.0, 0.01, 0.99
         )


### PR DESCRIPTION
Rename getter/query methods to use get_ or convert_ prefixes for consistency with the imperative verb phrase convention used elsewhere.

Amp-Thread-ID: https://ampcode.com/threads/T-019c5a10-0b94-7408-8993-8da3bb4f6730