### PR TITLE
Fix Slack dependency notification not finding previous pyproject.toml

### DIFF
--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -18,6 +18,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          sparse-checkout: |
+            .
 
       - name: Check if tool.robotpy changed
         id: check


### PR DESCRIPTION
[This notification](https://frc-4774.slack.com/archives/C0ELLBBQX/p1771111860854989) for 30f75abc5804bcdcbfa0a3781579d93971622e4a shouldn't have sent.

<img width="1228" height="276" alt="incoming-webhook 10:31 📣 Robot dependencies have been updated! Please rebase all open PRs, and download the new dependencies by following the [instructions in the readme](https://github.com/thedropbears/pyrebuilt#install-dependencies). Triggered on push for commit 30f75abc5804bcdcbfa0a3781579d93971622e4a" src="https://github.com/user-attachments/assets/be1bb1db-a4a2-4636-9a33-2d8d7a301c8d" />

This was due to [this error](https://github.com/thedropbears/pyrebuilt/actions/runs/22026105895/job/63642875417#step:3:16):

```
fatal: path 'pyproject.toml' exists on disk, but not in '49e0bb414798844d97ccf3f526da8350c01526f4'
```

Turns out GitHub Actions doesn't `set -o pipefail` by default; only `-e`. (Well, I guess the alternative was that I broke these notifications completely. ¯\\\_(ツ)_/¯)

The `git` command failed because `fetch-depth` defaults to `1`, so it only fetched `HEAD`. Fix this by fetching all the history, but still try to keep it fast by only fetching the files in the top-level of the repo.

I hate bash and I hate GitHub Actions.