### PR TITLE
Migrate from legacy ruff pre-commit hook alias

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.0
     hooks:
-      - id: ruff
+      - id: ruff-check
         args:
           - "--fix"
       - id: ruff-format


### PR DESCRIPTION
### Problem

pre-commit output:
```
ruff (legacy alias)......................................................Passed
ruff format..............................................................Passed
```

### Solution

Switch to the new clearer name per the docs. https://docs.astral.sh/ruff/integrations/#pre-commit