### PR TITLE
Configure climber motor to use CANdi as hardware limit switch source

### DIFF
--- a/components/climber.py
+++ b/components/climber.py
@@ -110,13 +110,7 @@ class ClimberComponent:
         self.try_index()
 
         if self.has_indexed:
-            self.climber_motor.set_control(
-                PositionVoltage(
-                    self.target_pos,
-                    limit_forward_motion=self.at_extension_limit(),
-                    limit_reverse_motion=self.at_retraction_limit(),
-                )
-            )
+            self.climber_motor.set_control(PositionVoltage(self.target_pos))
         else:
             self.climber_motor.set_control(
                 VoltageOut(


### PR DESCRIPTION
The intention around wiring the climber limit switches to a CANdi was to allow the motor controller to respond faster to the limit switches. Actually configure the motor controller to read from the CANdi.

Amp-Thread-ID: https://ampcode.com/threads/T-019ca17a-a5bb-77e7-8beb-6d50d8dd548a