### PR TITLE
ballistics: Cleanup lookup tables logic

### DIFF
--- a/components/ballistics.py
+++ b/components/ballistics.py
@@ -92,7 +92,6 @@ class BallisticsComponent:
         angle_to_target = (self.target_position - current_position).angle()
 
         if self.use_ballistics:
-            target_hood_angle = 0.0
             required_turret_angle = angle_to_target - current_rotation
             target_turret_angle = required_turret_angle.radians()
             # Check if distance is within range of distance table and switch if necessary
@@ -100,7 +99,7 @@ class BallisticsComponent:
                 for table_pair in self.tables:
                     if table_pair.is_within_range(distance_to_target):
                         self.active_table = table_pair
-                        target_hood_angle = table_pair.hood_angle
+            target_hood_angle = self.active_table.hood_angle
             self.target_flywheel_speed = np.interp(
                 distance_to_target,
                 self.active_table.dist,


### PR DESCRIPTION
The lookup table switching logic introduced in #149 is currently a bit verbose. Make it less repetitive by making the ballistics component store the active table in a single attribute, and refactor the common distance check logic into a method on a new type for a lookup table.

This also fixes a bug where when we move out of range of all our lookup tables, or when we _don't_ move between our lookup tables, the ballistics calculation would send the turret hood to the 0 angle.