### PR TITLE
flywheel: Use wpimath.units.turns_per_second type alias

### DIFF
--- a/components/ballistics.py
+++ b/components/ballistics.py
@@ -8,7 +8,7 @@ from wpimath import units
 from wpimath.geometry import Rotation2d, Translation2d
 
 from components.chassis import ChassisComponent
-from components.shooter import ShooterComponent, rotations_per_second
+from components.shooter import ShooterComponent
 from components.turret import TurretComponent
 
 # TODO: Tune lookup tables for use
@@ -73,7 +73,7 @@ class BallisticsComponent:
 
     def force_solution(
         self,
-        desired_flywheel_speed: rotations_per_second,
+        desired_flywheel_speed: units.turns_per_second,
         desired_turret_bearing: Rotation2d,
         desired_hood_angle: units.radians,
     ) -> None:

--- a/components/shooter.py
+++ b/components/shooter.py
@@ -10,8 +10,6 @@ from ids import SparkId, TalonId
 from utilities.functions import clamp
 from utilities.rev import configure_spark_reset_and_persist
 
-rotations_per_second = float
-
 
 class ShooterComponent:
     target_shooter_rps = will_reset_to(0.0)
@@ -81,7 +79,7 @@ class ShooterComponent:
         )
 
     @feedback
-    def get_flywheel_error(self) -> rotations_per_second:
+    def get_flywheel_error(self) -> units.turns_per_second:
         return self.flywheel_motor.get_closed_loop_error().value
 
     def pitch_relative(self, angle: units.radians):
@@ -90,7 +88,7 @@ class ShooterComponent:
     def pitch_to(self, angle: units.radians):
         self.target_hood_angle = angle
 
-    def set_flywheel(self, speed: rotations_per_second):
+    def set_flywheel(self, speed: units.turns_per_second):
         self.target_shooter_rps = speed
 
     def execute(self) -> None:


### PR DESCRIPTION
A type alias for rotations per second already exists in wpimath.

I don't really mind if we use it or not, but it does seem odd we use `wpimath.units` elsewhere in the shooter component and not for the flywheel speed.