### PR TITLE
ballistics: Change use_ballistics attribute to entire forced solution

### DIFF
--- a/components/ballistics.py
+++ b/components/ballistics.py
@@ -45,7 +45,6 @@ class BallisticsComponent:
 
     def __init__(self) -> None:
         self.target_position = Translation2d()
-        self.target_flywheel_speed = 0.0
         self.tables = (
             LookupTable(
                 DISTANCE_LOOKUP_30, SPEED_LOOKUP_30, math.radians(30), "30 degree table"


### PR DESCRIPTION
The `target_*` attributes are unused when `use_ballistics` is set to `False` (by calling `force_solution`). This makes the unused state entirely unrepresentable in the type system, to avoid any confusion around it.