### PR TITLE
Coast flywheel to stop when no command is received

### DIFF
--- a/components/shooter.py
+++ b/components/shooter.py
@@ -92,9 +92,12 @@ class ShooterComponent:
         self.target_shooter_rps = speed
 
     def execute(self) -> None:
-        self.flywheel_motor.set_control(
-            controls.VelocityVoltage(self.target_shooter_rps)
-        )
+        if self.target_shooter_rps != 0.0:
+            self.flywheel_motor.set_control(
+                controls.VelocityVoltage(self.target_shooter_rps)
+            )
+        else:
+            self.flywheel_motor.set_control(controls.CoastOut())
 
         self.target_hood_angle = clamp(
             self.target_hood_angle, self.MIN_HOOD_ANGLE, self.MAX_HOOD_ANGLE


### PR DESCRIPTION
When the shooter doesn't receive a command, previously it would try to hold a velocity of 0. Let it coast to a stop instead.