### PR TITLE
shooter: Fix pitch_relative unit handling

### DIFF
--- a/components/shooter.py
+++ b/components/shooter.py
@@ -114,7 +114,11 @@ class ShooterComponent:
         return self.flywheel_motor.get_closed_loop_error().value
 
     def pitch_relative(self, angle: units.radians):
-        self.pitch_to(self.target_hood_angle + angle / math.tau)
+        self.target_hood_angle = clamp(
+            self.target_hood_angle + angle / math.tau,
+            self.MIN_HOOD_ANGLE,
+            self.MAX_HOOD_ANGLE,
+        )
 
     def pitch_to(self, angle: units.radians):
         self.target_hood_angle = clamp(


### PR DESCRIPTION
This was passing turns into the `pitch_to()` method that was expecting radians.

Amp-Thread-ID: https://ampcode.com/threads/T-019ccc56-1607-76c9-baca-809b06b66ae7