### PR TITLE
Add vision measurements before chassis odometry

### DIFF
--- a/components/vision.py
+++ b/components/vision.py
@@ -72,6 +72,8 @@ class VisualLocalizer(HasPerLoopCache):
 
     reproj_error_threshold = tunable(2.0)
 
+    chassis: ChassisComponent
+
     def __init__(
         self,
         # The name of the camera in PhotonVision.
@@ -92,7 +94,6 @@ class VisualLocalizer(HasPerLoopCache):
         rotation_range: tuple[Rotation2d, Rotation2d],
         field: wpilib.Field2d,
         data_log: wpiutil.log.DataLog,
-        chassis: ChassisComponent,
     ) -> None:
         super().__init__()
         self.camera = PhotonCamera(name)
@@ -155,7 +156,6 @@ class VisualLocalizer(HasPerLoopCache):
             data_log, name + "_vision_pose"
         )
 
-        self.chassis = chassis
         self.current_reproj = 0.0
         self.has_multitag = False
 

--- a/robot.py
+++ b/robot.py
@@ -27,6 +27,8 @@ from utilities.scalers import rescale_js
 
 
 class MyRobot(magicbot.MagicRobot):
+    # These components have specific ordering concerns with data flow.
+    port_vision: VisualLocalizer
     chassis: ChassisComponent
     targeter: Targeter
 
@@ -42,7 +44,6 @@ class MyRobot(magicbot.MagicRobot):
     intake: IntakeComponent
     turret: TurretComponent
     leds: LEDComponent
-    port_vision: VisualLocalizer
 
     # Driving constraints
     upper_max_speed = tunable(2.0)  # m/s
@@ -251,6 +252,13 @@ class MyRobot(magicbot.MagicRobot):
         if self.gamepad.getYButton():
             self.shooter.pitch_to(math.radians(self.test_hood_angle))
 
+        if self.gamepad.getLeftStickButton():
+            self.port_vision.zero_servo_()
+        elif self.gamepad.getRightStickButton():
+            self.port_vision.full_range_servo_()
+
+        self.port_vision.execute()
+        self.chassis.execute()
         self.targeter.execute()
 
         if self.gamepad.getRightTriggerAxis() > 0.5 or self.gamepad.getXButton():
@@ -266,7 +274,6 @@ class MyRobot(magicbot.MagicRobot):
             self.ballistics.energise_flywheels()
             self.ballistics.execute()
 
-        self.chassis.execute()
         self.gobbler.execute()
         self.shooter.execute()
         self.climber.execute()
@@ -274,13 +281,6 @@ class MyRobot(magicbot.MagicRobot):
         self.leds.execute()
         self.turret.execute()
         self.hopper.execute()
-
-        if self.gamepad.getLeftStickButton():
-            self.port_vision.zero_servo_()
-        elif self.gamepad.getRightStickButton():
-            self.port_vision.full_range_servo_()
-
-        self.port_vision.execute()
 
     def disabledPeriodic(self) -> None:
         self.leds.set_disabled_lights()
@@ -295,8 +295,8 @@ class MyRobot(magicbot.MagicRobot):
         self.climber.try_index()
 
         self.chassis.update_alliance()
-        self.chassis.update_odometry()
         self.port_vision.execute()
+        self.chassis.update_odometry()
         self.leds.execute()
 
     def robotPeriodic(self) -> None:


### PR DESCRIPTION
Ideally we should be adding our wheel odometry to the pose estimator _after_ adding a vision estimate, which means we want vision to execute before the chassis. Now that magicbot's dependency order is decoupled from execution order (https://github.com/robotpy/robotpy-wpilib-utilities/pull/224), we can do this :tada:

Stacked on:

- #242